### PR TITLE
fix: update variable parsing by looking at number of opening/closing parentheses

### DIFF
--- a/mkdocs_snakemake_rule_plugin/markdown.py
+++ b/mkdocs_snakemake_rule_plugin/markdown.py
@@ -97,7 +97,7 @@ def markdown_table(rule_source, rule_schema):
     sections = ["input", "output", "params", "log", "benchmark",
                 "resources", "threads", "conda", "container",
                 "message", "shell", "wrapper", "script", "R"]
-    
+
     def get_input_variabels(rule_source, include_section_regex, exclude_section_regex):
         rows = iter(rule_source.split("\n"))
         section_dict = {}


### PR DESCRIPTION

Within a Snakemake rule, the input and output sections can include functions with key-named variables, introducing equal signs within their values. In the past, our implementation relied on equal signs as indicators to identify the end of a variable. However, this approach became problematic when dealing with key-named variables, as it led to invalid parsing.

With the introduction of the new approach, we've addressed this challenge. Instead of relying on equal signs, the new method utilizes a count of opening and closing parentheses. This count is used to accurately determine when all information for a variable, including those with key names, has been successfully read.

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve